### PR TITLE
Hotfix/file tab focus

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -78,7 +78,7 @@ void code_contents_print() {
 
         // print row & col
         wattron(opened_file_tab, A_UNDERLINE);
-        mvwprintw(opened_file_tab, 0, 0, "%4d|%5d", status->row, status->col);
+        mvwprintw(opened_file_tab, 0, 0, "%4d|%5d", status->row + 1, status->col + 1);
         wattroff(opened_file_tab, A_UNDERLINE);
         wrefresh(opened_file_tab);
     }

--- a/src/global.h
+++ b/src/global.h
@@ -36,7 +36,6 @@ typedef struct {
     FileStatus *head;
     int cnt;
     FileStatus *focus;
-    int focus_strlen;
 } OpenFileInfo;
 
 enum MenuTab {

--- a/src/main.c
+++ b/src/main.c
@@ -29,11 +29,6 @@ int main(int argc, char **argv) {
 	new_opened_file_tab("testFile.c", "");
 	new_opened_file_tab("testFile2.c", "");
 
-	// opened_file_info->head->modified = 1;
-
-	// close_unsaved_caution(1);
-
-
 	while(1) {
 		input_char = getch();
 		if(input_control(input_char) == -1)

--- a/src/openedFileTab.c
+++ b/src/openedFileTab.c
@@ -80,9 +80,6 @@ int new_opened_file_tab(char *file_name, char *full_path) {
 
     // update opened_file_info
     opened_file_info->focus = node;
-    if(opened_file_info->cnt == 0) {
-        opened_file_info->focus_strlen = strlen(file_name);
-    }
     node->next = opened_file_info->head;
     opened_file_info->head = node;
     opened_file_info->cnt++;
@@ -140,7 +137,6 @@ void del_opened_file_tab(int idx) {
     if(focus_flag == 1) {
         if(opened_file_info->cnt > 0) {
             opened_file_info->focus = opened_file_info->head;
-            opened_file_info->focus_strlen = strlen(opened_file_info->head->file_name);
         } else {
             opened_file_info->focus = NULL;
         }

--- a/src/openedFileTab.c
+++ b/src/openedFileTab.c
@@ -79,8 +79,8 @@ int new_opened_file_tab(char *file_name, char *full_path) {
     node->last_saved = time(NULL);
 
     // update opened_file_info
+    opened_file_info->focus = node;
     if(opened_file_info->cnt == 0) {
-        opened_file_info->focus = node;
         opened_file_info->focus_strlen = strlen(file_name);
     }
     node->next = opened_file_info->head;


### PR DESCRIPTION
- file tab focus : now newly opened file always get foucs
- redundant variable erased : OpenFileInfo.focus_len
- row & col print policy changed (from 0 to from 1)