### PR TITLE
Non-block malloc fix

### DIFF
--- a/src/errLog.c
+++ b/src/errLog.c
@@ -7,7 +7,7 @@
 #include "errLog.h"
 
 void start_logging() {
-    int log_fd = open(LOG_FILE_NAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR | S_IRWXG | S_IRWXO);
+    int log_fd = open(LOG_FILE_NAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IRGRP);
     dup2(log_fd, 2);
     close(log_fd);
 }

--- a/src/errLog.c
+++ b/src/errLog.c
@@ -7,7 +7,7 @@
 #include "errLog.h"
 
 void start_logging() {
-    int log_fd = open(LOG_FILE_NAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRWXU | S_IRWXG | S_IRWXO);
+    int log_fd = open(LOG_FILE_NAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR | S_IRWXG | S_IRWXO);
     dup2(log_fd, 2);
     close(log_fd);
 }

--- a/src/uibase.c
+++ b/src/uibase.c
@@ -3,6 +3,8 @@
 #include <curses.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <termios.h>
+#include <fcntl.h>
 
 #include "global.h"
 #include "uibase.h"
@@ -28,6 +30,7 @@ void ui_init() {
     keypad(stdscr, true); // enables to read dynamic key input
     noecho();
     curs_set(0); // hide cursor
+    nodelay(stdscr, false); // let getch run in blocking mode
 
     // color check
     if(has_colors() == FALSE) {
@@ -49,6 +52,20 @@ void ui_init() {
     signal(SIGINT, SIG_IGN);
 
     // notice : print ui to stdscr must not work here
+}
+
+// not in use
+void non_cannonical() {
+    struct termios ttyinfo;
+    if (tcgetattr(0, &ttyinfo) == -1){
+		perror("cannot get params about stdin");
+		exit(1);
+	}
+    ttyinfo.c_lflag &= ~ICANON;
+    ttyinfo.c_cc[VMIN] = 1;
+    int tflag = fcntl(0, F_GETFL);
+    tflag |= O_NDELAY;
+    fcntl(0, F_SETFL, tflag);
 }
 
 void ui_terminate() {

--- a/src/uibase.h
+++ b/src/uibase.h
@@ -33,6 +33,7 @@ extern WINDOW *contents;
 
 /* METHOD */
 void ui_init();
+void non_cannonical();
 void ui_terminate();
 void ui_set_whole();
 void window_reset();


### PR DESCRIPTION
Fixed memory allocation error induced by non-blocking getch() call(typically from fast typing in code tab) by changing its mode as blocking